### PR TITLE
Handle missing columns in streamlit multiselect defaults

### DIFF
--- a/app_v2_8_unified_pro_full_safe_clean.py
+++ b/app_v2_8_unified_pro_full_safe_clean.py
@@ -90,7 +90,19 @@ with tab_browse:
     with col6:
         dealscore_min = st.slider("Min DealScore %", 0.0, 100.0, 0.0)
     with col7:
-        show_cols = st.multiselect("Columns", options=list(df.columns), default=["Location","Tenant","Area_Sft","Price_Crore","Rent_Lakh","Price_per_Sft","Rent_per_Sft","Gross_Yield_%","DealScore_%"])
+        default_cols = [
+            "Location",
+            "Tenant",
+            "Area_Sft",
+            "Price_Crore",
+            "Rent_Lakh",
+            "Price_per_Sft",
+            "Rent_per_Sft",
+            "Gross_Yield_%",
+            "DealScore_%",
+        ]
+        default_cols = [c for c in default_cols if c in df.columns]
+        show_cols = st.multiselect("Columns", options=list(df.columns), default=default_cols)
 
     q = df.copy()
     if sel_locs:


### PR DESCRIPTION
## Summary
- Filter default column selections to only include fields present in the dataset

## Testing
- `pip install -r requirements.txt`
- `timeout 5s streamlit run app_v2_8_unified_pro_full_safe_clean.py --server.headless true --server.port 8501`
- `timeout 5s streamlit run app_v2_7_unified_pro.py --server.headless true --server.port 8502`
- `python validate_properties_v2.py PROPERTY_LIST_ENRICHED.xlsx` *(fails: 17 validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be3ae147888327b835a1428ca4422b